### PR TITLE
fix(deploy): allow Vercel build without DATABASE_URL at build time

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -51,7 +51,12 @@ OPENAI_API_KEY=[YOUR_OPENAI_API_KEY]
 # -----------------------------------------------------------------------------
 # Docker: Automatically configured — no need to set this.
 # Local development: Set your PostgreSQL connection string.
-# Cloud providers (Neon, Supabase, etc.): Add ?sslmode=require
+# Cloud providers (Neon, Supabase, etc.): use the provider connection URI.
+#
+# Supabase (Project Settings → Database → Connection string → URI):
+# - Runtime/serverless (Vercel): use Transaction pooler on port 6543
+#   DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
+# - Migrations (run locally once): use Direct connection on port 5432
 #
 # DATABASE_URL=postgresql://user:password@localhost:5432/morphic
 DATABASE_URL=[YOUR_DATABASE_URL]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -217,6 +217,43 @@ SUPABASE_SECRET_KEY=[YOUR_SUPABASE_SECRET_KEY]
    - **Publishable Key**: Settings > API Keys > publishable key (`sb_publishable_...`)
    - **Secret Key**: Settings > API Keys > secret key (`sb_secret_...`)
 
+4. Configure redirect URLs in **Authentication → URL Configuration**:
+   - Site URL: your deployed app URL (for example `https://your-app.vercel.app`)
+   - Redirect URLs: `https://your-app.vercel.app/auth/oauth`, `/auth/update-password`, `/auth/confirm`
+
+### Deploying on Vercel with Supabase
+
+Use one Supabase project for **auth** and **Postgres** (chat history):
+
+1. Restore/unpause the Supabase project if it was paused.
+
+2. In **Vercel → Project → Settings → Environment Variables**, set:
+
+```bash
+# Database (Supabase → Project Settings → Database → Connection string → URI → Transaction pooler)
+DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
+
+# Auth
+ENABLE_AUTH=true
+NEXT_PUBLIC_SUPABASE_URL=https://[project-ref].supabase.co
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
+SUPABASE_SECRET_KEY=sb_secret_...
+
+# Required app keys
+OPENAI_API_KEY=...
+TAVILY_API_KEY=...
+```
+
+3. Run database migrations once from your machine using the **Direct** Supabase connection string (port 5432):
+
+```bash
+DATABASE_URL="postgresql://postgres.[project-ref]:[password]@db.[project-ref].supabase.co:5432/postgres" bun migrate
+```
+
+4. Redeploy on Vercel after changing environment variables.
+
+**Note:** `NEXT_PUBLIC_*` Supabase variables are embedded at build time. Always redeploy after updating them.
+
 ## Guest Mode
 
 Guest mode allows users to try Morphic without creating an account. Guest sessions are ephemeral — no chat history is stored.

--- a/lib/db/__tests__/index.test.ts
+++ b/lib/db/__tests__/index.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveDatabaseConnectionString } from '../connection-string'
+
+describe('resolveDatabaseConnectionString', () => {
+  it('prefers DATABASE_RESTRICTED_URL over DATABASE_URL', () => {
+    expect(
+      resolveDatabaseConnectionString({
+        NODE_ENV: 'production',
+        DATABASE_URL: 'postgres://owner@localhost:5432/db',
+        DATABASE_RESTRICTED_URL: 'postgres://app_user@localhost:5432/db'
+      })
+    ).toBe('postgres://app_user@localhost:5432/db')
+  })
+
+  it('uses a placeholder during production build when unset', () => {
+    expect(
+      resolveDatabaseConnectionString({
+        NODE_ENV: 'production',
+        NEXT_PHASE: 'phase-production-build'
+      })
+    ).toContain('127.0.0.1:5432/build')
+  })
+
+  it('throws at runtime when unset outside build and test', () => {
+    expect(() =>
+      resolveDatabaseConnectionString({
+        NODE_ENV: 'production'
+      })
+    ).toThrow(
+      'DATABASE_URL or DATABASE_RESTRICTED_URL environment variable is not set'
+    )
+  })
+
+  it('uses the test connection string in test mode', () => {
+    expect(
+      resolveDatabaseConnectionString({
+        NODE_ENV: 'test'
+      })
+    ).toBe('postgres://user:pass@localhost:5432/testdb')
+  })
+})

--- a/lib/db/connection-string.ts
+++ b/lib/db/connection-string.ts
@@ -1,0 +1,32 @@
+const BUILD_PLACEHOLDER_URL =
+  'postgresql://build:build@127.0.0.1:5432/build?sslmode=disable'
+
+export function resolveDatabaseConnectionString(
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const configured = env.DATABASE_RESTRICTED_URL ?? env.DATABASE_URL
+
+  if (configured) {
+    return configured
+  }
+
+  if (env.NODE_ENV === 'test') {
+    return 'postgres://user:pass@localhost:5432/testdb'
+  }
+
+  // Next.js evaluates server modules while collecting route data at build time.
+  // Avoid failing the production build when DATABASE_URL is only configured at runtime.
+  if (env.NEXT_PHASE === 'phase-production-build') {
+    return BUILD_PLACEHOLDER_URL
+  }
+
+  throw new Error(
+    'DATABASE_URL or DATABASE_RESTRICTED_URL environment variable is not set'
+  )
+}
+
+export function isDatabaseBuildPhase(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return env.NEXT_PHASE === 'phase-production-build'
+}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -2,6 +2,10 @@ import { sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 
+import {
+  isDatabaseBuildPhase,
+  resolveDatabaseConnectionString
+} from './connection-string'
 import * as relations from './relations'
 import * as schema from './schema'
 
@@ -9,29 +13,9 @@ import * as schema from './schema'
 // Use restricted user for application if available, otherwise fall back to regular user
 const isDevelopment = process.env.NODE_ENV === 'development'
 const isTest = process.env.NODE_ENV === 'test'
+const isBuildPhase = isDatabaseBuildPhase()
 
-if (
-  !process.env.DATABASE_URL &&
-  !process.env.DATABASE_RESTRICTED_URL &&
-  !isTest
-) {
-  throw new Error(
-    'DATABASE_URL or DATABASE_RESTRICTED_URL environment variable is not set'
-  )
-}
-
-// Connection with connection pooling for server environments
-// Prefer restricted user for application runtime
-const connectionString =
-  process.env.DATABASE_RESTRICTED_URL ?? // Prefer restricted user
-  process.env.DATABASE_URL ??
-  (isTest ? 'postgres://user:pass@localhost:5432/testdb' : undefined)
-
-if (!connectionString) {
-  throw new Error(
-    'DATABASE_URL or DATABASE_RESTRICTED_URL environment variable is not set'
-  )
-}
+const connectionString = resolveDatabaseConnectionString()
 
 // Log which connection is being used (for debugging)
 if (isDevelopment) {
@@ -47,8 +31,8 @@ if (isDevelopment) {
 // DATABASE_SSL_DISABLED=true disables SSL completely (for local/Docker PostgreSQL)
 // Default is to enable SSL with certificate verification (for cloud databases like Neon, Supabase)
 const sslConfig =
-  process.env.DATABASE_SSL_DISABLED === 'true'
-    ? false // Disable SSL entirely for local PostgreSQL
+  process.env.DATABASE_SSL_DISABLED === 'true' || isBuildPhase
+    ? false // Disable SSL entirely for local PostgreSQL and build-time placeholder
     : { rejectUnauthorized: true } // Enable SSL with verification for cloud DBs
 
 const client = postgres(connectionString, {
@@ -56,6 +40,8 @@ const client = postgres(connectionString, {
   prepare: false,
   max: 20 // Max 20 connections
 })
+
+export { resolveDatabaseConnectionString } from './connection-string'
 
 export const db = drizzle(client, {
   schema: { ...schema, ...relations }
@@ -65,7 +51,7 @@ export const db = drizzle(client, {
 export type Schema = typeof schema
 
 // Verify restricted user permissions on startup
-if (process.env.DATABASE_RESTRICTED_URL && !isTest) {
+if (process.env.DATABASE_RESTRICTED_URL && !isTest && !isBuildPhase) {
   // Only run verification in server environments, not during build
   if (typeof window === 'undefined' && process.env.NODE_ENV !== 'production') {
     ;(async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Vercel deployment failures caused by missing `DATABASE_URL` during the Next.js production build.

## Root cause

Vercel build was failing with:

```text
Error: DATABASE_URL or DATABASE_RESTRICTED_URL environment variable is not set
Failed to collect page data for /api/feedback
```

`lib/db/index.ts` threw at import time while Next.js collected route data, even though the database is only needed at runtime.

## Fix

- Resolve the database URL lazily via `lib/db/connection-string.ts`
- Use a build-time placeholder when `NEXT_PHASE=phase-production-build`
- Still require `DATABASE_URL` at runtime for actual DB access

## Supabase + Vercel docs

Added deployment instructions for using one Supabase project for:
- **Auth** (`NEXT_PUBLIC_SUPABASE_*`, `SUPABASE_SECRET_KEY`)
- **Postgres chat history** (`DATABASE_URL` via transaction pooler)

Includes one-time migration command using Supabase direct connection.

## Test plan

- [x] Build succeeds with no `DATABASE_URL`
- [x] `bun run test lib/db/__tests__/index.test.ts`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun format:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c1ddb77-2a0f-47c6-94c5-b4dd2d1331a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c1ddb77-2a0f-47c6-94c5-b4dd2d1331a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

